### PR TITLE
Update runtime to 21.08

### DIFF
--- a/org.js.nuclear.Nuclear.json
+++ b/org.js.nuclear.Nuclear.json
@@ -3,7 +3,11 @@
     "branch": "stable",
     "command": "run.sh",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "20.08",
+    "base-version": "21.08",    
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "21.08",
+    "sdk": "org.freedesktop.Sdk",
+    "separate-locales": false,
     "finish-args": [
         "--share=network",
         "--share=ipc",
@@ -53,9 +57,5 @@
                 }
             ]
         }
-    ],
-    "runtime": "org.freedesktop.Platform",
-    "runtime-version": "20.08",
-    "sdk": "org.freedesktop.Sdk",
-    "separate-locales": false
+    ]
 }


### PR DESCRIPTION
Also move runtime and base-sdk together, avoiding confusing next time around