### PR TITLE
Update org.js.nuclear.Nuclear.json

### DIFF
--- a/org.js.nuclear.Nuclear.json
+++ b/org.js.nuclear.Nuclear.json
@@ -13,8 +13,9 @@
         "--share=ipc",
         "--socket=x11",
         "--device=dri",
-        "--filesystem=home",
-        "--socket=pulseaudio"
+        "--filesystem=xdg-music",
+        "--socket=pulseaudio",
+        "--own-name=org.mpris.MediaPlayer2.nuclear"
     ],
     "modules": [
         {


### PR DESCRIPTION
I added media control functionality and I restricted filesystem permissions to just use the xdg-music folder since that's all the app really needs to obtain local music. I think the app will run fine even without filesystem any permissions but if that doesn't work we could also add something like /var/lib/flatpak/app. It should work though.