### PR TITLE
Update to a supported base and platform

### DIFF
--- a/org.js.nuclear.Nuclear.json
+++ b/org.js.nuclear.Nuclear.json
@@ -2,9 +2,9 @@
     "app-id": "org.js.nuclear.Nuclear",
     "command": "run.sh",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "22.08",    
+    "base-version": "24.08",    
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "22.08",
+    "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
     "separate-locales": false,
     "finish-args": [


### PR DESCRIPTION
Base 22.08 is EOL and unsupported.